### PR TITLE
Task 6: Role-Based Access Control

### DIFF
--- a/src/main/java/com/example/techolution/security/ResourceSecurityConfig.java
+++ b/src/main/java/com/example/techolution/security/ResourceSecurityConfig.java
@@ -2,10 +2,14 @@ package com.example.techolution.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
@@ -33,6 +37,28 @@ public class ResourceSecurityConfig {
                 .build();
 
         return new InMemoryUserDetailsManager(pankaj, sharad, admin);
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http.authorizeHttpRequests(configurer ->
+                configurer
+                        .requestMatchers(HttpMethod.GET, "/api/users").hasRole("EMPLOYEE")
+                        .requestMatchers(HttpMethod.GET, "/api/users/**").hasRole("EMPLOYEE")
+                        .requestMatchers(HttpMethod.POST, "/api/users").hasRole("MANAGER")
+                        .requestMatchers(HttpMethod.PUT, "/api/users").hasRole("MANAGER")
+                        .requestMatchers(HttpMethod.DELETE, "/api/users/**").hasRole("ADMIN")
+        );
+
+        // use HTTP Basic authentication
+        http.httpBasic(Customizer.withDefaults());
+
+        // disable Cross Site Request Forgery (CSRF)
+        // in general, not required for stateless REST APIs that use POST, PUT, DELETE and/or PATCH
+        http.csrf(csrf -> csrf.disable());
+
+        return http.build();
     }
 }
 

--- a/src/test/java/com/example/techolution/UserControllerIntegrationTest.java
+++ b/src/test/java/com/example/techolution/UserControllerIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.example.techolution;
 
+import com.example.techolution.entity.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -7,9 +9,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -21,6 +26,9 @@ public class UserControllerIntegrationTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @Test
     public void testUnauthenticatedAccess() throws Exception {
         mockMvc.perform(get("/api/users"))
@@ -28,28 +36,14 @@ public class UserControllerIntegrationTest {
     }
 
     @Test
-    @WithMockUser(username = "pankaj", roles = "EMPLOYEE")
-    public void testAuthenticatedAccessAsEmployee() throws Exception {
+    @WithMockUser(roles = "EMPLOYEE")
+    public void testAuthenticatedEmployeeAccess() throws Exception {
         mockMvc.perform(get("/api/users"))
                 .andExpect(status().isOk());
     }
 
     @Test
-    @WithMockUser(username = "sharad", roles = "MANAGER")
-    public void testAuthenticatedAccessAsManager() throws Exception {
-        mockMvc.perform(get("/api/users"))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @WithMockUser(username = "admin", roles = "ADMIN")
-    public void testAuthenticatedAccessAsAdmin() throws Exception {
-        mockMvc.perform(get("/api/users"))
-                .andExpect(status().isOk());
-    }
-
-    @Test
-    @WithMockUser(username = "pankaj", roles = "EMPLOYEE")
+    @WithMockUser(roles = "EMPLOYEE")
     public void testGetAllUsersAsEmployee() throws Exception {
         mockMvc.perform(get("/api/users"))
                 .andExpect(status().isOk())
@@ -58,11 +52,49 @@ public class UserControllerIntegrationTest {
     }
 
     @Test
-    @WithMockUser(username = "pankaj", roles = "EMPLOYEE")
-    public void testDeleteUserAsEmployee() throws Exception {
+    @WithMockUser(roles = "EMPLOYEE")
+    public void testGetUserByIdAsEmployee() throws Exception {
+        Long userId = 1L;
+        mockMvc.perform(get("/api/users/{userId}", userId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(userId));
+    }
+
+    @Test
+    @WithMockUser(roles = "MANAGER")
+    public void testCreateUserAsManager() throws Exception {
+        User newUser = new User(); // create a new user instance
+
+        ResultActions resultActions = mockMvc.perform(post("/api/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(newUser)));
+
+        resultActions.andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").exists());
+    }
+
+    @Test
+    @WithMockUser(roles = "MANAGER")
+    public void testUpdateUserAsManager() throws Exception {
+        Long userId = 1L;
+        User updatedUser = new User(); // create an updated user instance
+
+        mockMvc.perform(put("/api/users/{userId}", userId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updatedUser)))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.id").value(userId));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    public void testDeleteUserAsAdmin() throws Exception {
         Long userId = 1L;
 
         mockMvc.perform(delete("/api/users/{userId}", userId))
-                .andExpect(status().isForbidden()); // Expecting a 403 Forbidden for unauthorized access
+                .andExpect(status().isOk());
     }
 }


### PR DESCRIPTION
1. Extended the security configuration to include role-based access control.
2. Define roles (e.g., ROLE_USER, ROLE_ADMIN) and associate them with users.
3. Restrict certain endpoints based on user roles.